### PR TITLE
change name to title in config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -82,7 +82,7 @@ sass:
 collections:
   transcripts:
     output: true
-    permalink: /:collection/:name
+    permalink: /:collection/:title
   howto:
     output: true
     permalink: /:collection/:name


### PR DESCRIPTION
This should fix the whole template and ensure that the underscore doesn't get replaced. And it means you can get rid of the permalink line on your transcript. 

I'm going to make this change to the base model as well. Sorry about the bug! 

